### PR TITLE
Fix profile save navigation and feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,14 @@
 
             try {
                 await setDoc(doc(db, "users", currentUser.uid), profileData, { merge: true });
-                // Auth state listener will automatically navigate to farm list
+
+                showToast("Profile saved successfully!", "success");
+                userProfile = profileData; // Update local profile data
+                document.getElementById('welcome-message').textContent = `Welcome, ${userProfile.fullName}`;
+                loadFarms();
+                showScreen('farmList');
+                document.getElementById('add-farm-btn').style.display = 'flex';
+
             } catch (error) {
                 console.error("Error saving profile:", error);
                 showToast("Could not save profile. Please check connection.", 'error');


### PR DESCRIPTION
This commit fixes a bug where you were not navigated to the farm list screen after saving your profile.

Changes:
- Updated the `save-profile-btn` event listener to provide a success toast notification.
- Manually trigger the navigation to the farm list screen after a successful profile save.
- Update the local `userProfile` object to ensure the UI is consistent.