### PR TITLE
fix: Correct Firestore collection path for submission syncing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@
                     const { id, farmId, ...dataToSync } = submission;
                     if (!farmId) continue;
 
-                    const submissionsCollection = collection(db, 'users', currentUser.uid, 'farms', farmId, 'submissions');
+                    const submissionsCollection = collection(db, 'users', currentUser.uid, 'farmLots', farmId, 'submissions');
                     await addDoc(submissionsCollection, dataToSync);
                 }
 


### PR DESCRIPTION
The `syncSubmissionOutbox` function was using an incorrect Firestore path (`/users/{uid}/farms/...`) to sync submissions from IndexedDB. The correct collection name is `farmLots`.

This commit updates the path to `users/{uid}/farmLots/...`, aligning it with the rest of the application and fixing the bug that prevented offline submissions from syncing correctly.