### PR TITLE
feat: Add descriptive notifications for CRUD operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1252,7 +1252,7 @@
                 try {
                     const farmDocRef = doc(db, 'users', currentUser.uid, 'farmLots', currentFarmId);
                     await deleteDoc(farmDocRef);
-                    showToast('Farm plot deleted successfully!', 'success');
+                    showToast('The farm plot has been successfully deleted.', 'success');
                     currentFarmId = null;
                     showScreen('farmList');
                 } catch (error) {
@@ -1288,13 +1288,13 @@
                     farmData.updatedAt = serverTimestamp();
                     const farmDocRef = doc(db, 'users', currentUser.uid, 'farmLots', currentFarmId);
                     await updateDoc(farmDocRef, farmData);
-                    showToast('Farm plot updated successfully!', 'success');
+                    showToast('The farm plot details have been successfully updated.', 'success');
                 } else {
                     // Create new document
                     farmData.createdAt = serverTimestamp();
                     const farmLotsCollection = collection(db, 'users', currentUser.uid, 'farmLots');
                     await addDoc(farmLotsCollection, farmData);
-                    showToast('Farm plot saved successfully!', 'success');
+                    showToast('A new farm plot has been successfully created.', 'success');
                 }
 
                 // Reset state
@@ -1360,7 +1360,7 @@
                     submissionData.updatedAt = serverTimestamp();
                     const submissionDocRef = doc(db, 'users', currentUser.uid, 'farmLots', currentFarmId, 'submissions', currentSubmissionId);
                     await updateDoc(submissionDocRef, submissionData);
-                    showToast('Report updated successfully!', 'success');
+                    showToast('The report has been successfully updated.', 'success');
                 } else {
                     // Create new submission
                     submissionData.timestamp = serverTimestamp();
@@ -1368,7 +1368,7 @@
                     submissionData.gps_coordinates = { latitude: 17.5734, longitude: 120.3856 };
                     const submissionsCollection = collection(db, 'users', currentUser.uid, 'farmLots', currentFarmId, 'submissions');
                     await addDoc(submissionsCollection, submissionData);
-                    showToast('Report saved successfully!', 'success');
+                    showToast('A new report has been successfully submitted.', 'success');
                 }
 
                 // Reset state and form


### PR DESCRIPTION
This commit adds more descriptive success notifications (toasts) for the following actions:
- Creating a new farm lot
- Updating an existing farm lot
- Deleting a farm lot
- Adding a new report
- Updating an existing report

The toast messages have been updated to be more explicit, ensuring users receive clear confirmation of their actions.