### PR TITLE
feat: Implement side panel for case details on expert map

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,50 +306,69 @@
                     <h2 class="text-2xl font-bold">Expert Dashboard</h2>
                     <p id="expert-welcome-message" class="text-sm text-gray-600"></p>
                 </header>
-                <main class="flex-1 p-4 overflow-y-auto flex flex-col gap-6">
-                    <!-- Map Container -->
-                    <div class="bg-white p-4 rounded-lg shadow">
-                        <h3 class="text-lg font-bold mb-2">Pest & Disease Distribution Map</h3>
-                        <div id="expert-map" class="w-full h-[60vh] bg-gray-200 rounded-md shadow-inner"></div>
-                        <div id="expert-map-legend" class="mt-4"></div>
-                    </div>
+                <main class="flex-1 p-4 overflow-y-auto">
+                    <div class="flex flex-col lg:flex-row gap-6 h-full">
+                        <!-- Main Content -->
+                        <div class="flex-1 flex flex-col gap-6">
+                            <!-- Map Container -->
+                            <div class="bg-white p-4 rounded-lg shadow">
+                                <h3 class="text-lg font-bold mb-2">Pest & Disease Distribution Map</h3>
+                                <div id="expert-map" class="w-full h-[60vh] bg-gray-200 rounded-md shadow-inner"></div>
+                                <div id="expert-map-legend" class="mt-4"></div>
+                            </div>
 
-                    <!-- Stats and Data Extraction Container -->
-                    <div class="space-y-6">
-                        <!-- Stats -->
-                        <div class="bg-white p-4 rounded-lg shadow">
-                            <h3 class="text-lg font-bold mb-4">Key Statistics</h3>
-                            <div id="expert-stats-container" class="grid grid-cols-2 gap-4">
-                                <div class="text-center p-2 rounded-lg bg-gray-100">
-                                    <p class="text-2xl font-bold" id="stat-reports-count">0</p>
-                                    <p class="text-sm text-gray-600">Total Reports</p>
+                            <!-- Stats and Data Extraction Container -->
+                            <div class="space-y-6">
+                                <!-- Stats -->
+                                <div class="bg-white p-4 rounded-lg shadow">
+                                    <h3 class="text-lg font-bold mb-4">Key Statistics</h3>
+                                    <div id="expert-stats-container" class="grid grid-cols-2 gap-4">
+                                        <div class="text-center p-2 rounded-lg bg-gray-100">
+                                            <p class="text-2xl font-bold" id="stat-reports-count">0</p>
+                                            <p class="text-sm text-gray-600">Total Reports</p>
+                                        </div>
+                                        <div class="text-center p-2 rounded-lg bg-gray-100">
+                                            <p class="text-2xl font-bold" id="stat-diagnosed-count">0</p>
+                                            <p class="text-sm text-gray-600">Diagnosed</p>
+                                        </div>
+                                        <div class="text-center p-2 rounded-lg bg-gray-100">
+                                            <p class="text-2xl font-bold" id="stat-treated-count">0</p>
+                                            <p class="text-sm text-gray-600">Treated</p>
+                                        </div>
+                                        <div class="text-center p-2 rounded-lg bg-gray-100">
+                                            <p class="text-2xl font-bold" id="stat-pests-count">0</p>
+                                            <p class="text-sm text-gray-600">Unique Pests</p>
+                                        </div>
+                                        <div class="text-center p-2 rounded-lg bg-gray-100">
+                                            <p class="text-2xl font-bold" id="stat-diseases-count">0</p>
+                                            <p class="text-sm text-gray-600">Unique Diseases</p>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="text-center p-2 rounded-lg bg-gray-100">
-                                    <p class="text-2xl font-bold" id="stat-diagnosed-count">0</p>
-                                    <p class="text-sm text-gray-600">Diagnosed</p>
-                                </div>
-                                <div class="text-center p-2 rounded-lg bg-gray-100">
-                                    <p class="text-2xl font-bold" id="stat-treated-count">0</p>
-                                    <p class="text-sm text-gray-600">Treated</p>
-                                </div>
-                                <div class="text-center p-2 rounded-lg bg-gray-100">
-                                    <p class="text-2xl font-bold" id="stat-pests-count">0</p>
-                                    <p class="text-sm text-gray-600">Unique Pests</p>
-                                </div>
-                                <div class="text-center p-2 rounded-lg bg-gray-100">
-                                    <p class="text-2xl font-bold" id="stat-diseases-count">0</p>
-                                    <p class="text-sm text-gray-600">Unique Diseases</p>
+
+                                <!-- Data Extraction -->
+                                <div class="bg-white p-4 rounded-lg shadow">
+                                    <h3 class="text-lg font-bold mb-2">Data Extraction</h3>
+                                    <p class="text-sm text-gray-600 mb-4">Download a CSV file of all reports, diagnoses, and treatments.</p>
+                                    <button id="export-csv-btn" class="w-full bg-green-600 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-green-700">
+                                        Export All Data to CSV
+                                    </button>
                                 </div>
                             </div>
                         </div>
 
-                        <!-- Data Extraction -->
-                        <div class="bg-white p-4 rounded-lg shadow">
-                            <h3 class="text-lg font-bold mb-2">Data Extraction</h3>
-                            <p class="text-sm text-gray-600 mb-4">Download a CSV file of all reports, diagnoses, and treatments.</p>
-                            <button id="export-csv-btn" class="w-full bg-green-600 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-green-700">
-                                Export All Data to CSV
-                            </button>
+                        <!-- Case Details Side Panel -->
+                        <div id="expert-case-details-panel" class="hidden w-full lg:w-1/3 bg-white rounded-lg shadow-lg p-4 flex-col h-full">
+                            <div class="flex justify-between items-center mb-4 border-b pb-2">
+                                <h3 class="text-xl font-bold">Case Details</h3>
+                                <button id="close-expert-panel-btn" class="p-1 rounded-full hover:bg-gray-200">
+                                    <i data-lucide="x" class="w-6 h-6"></i>
+                                </button>
+                            </div>
+                            <div id="expert-panel-content" class="overflow-y-auto flex-1">
+                                <!-- Details will be populated here -->
+                                <p class="text-gray-500">Click on a highlighted area on the map to see details.</p>
+                            </div>
                         </div>
                     </div>
                 </main>
@@ -3423,6 +3442,84 @@
             }
         }
 
+        // --- Expert Panel Logic ---
+        const expertPanel = document.getElementById('expert-case-details-panel');
+        const expertPanelContent = document.getElementById('expert-panel-content');
+        const closeExpertPanelBtn = document.getElementById('close-expert-panel-btn');
+
+        function openExpertPanel(details) {
+            const { farm, submission, user, pestDisease } = details;
+
+            const reportDate = submission.timestamp?.toDate ? submission.timestamp.toDate().toLocaleDateString() : 'N/A';
+
+            const imagesHTML = (submission.imageDataUrls && submission.imageDataUrls.length > 0)
+                ? `<div class="grid grid-cols-2 gap-2 mt-2">${submission.imageDataUrls.map(url => `
+                    <a href="${url}" target="_blank" class="block">
+                        <img src="${url}" alt="Reported image" class="rounded-md object-cover aspect-square w-full hover:opacity-80 transition-opacity">
+                    </a>`).join('')}
+                  </div>`
+                : '<p class="text-sm text-gray-500">No images submitted.</p>';
+
+            let diagnosisHTML = '';
+            if (submission.initialDiagnosis) {
+                diagnosisHTML += `
+                    <div class="mt-2">
+                        <p class="text-sm"><strong class="font-semibold text-gray-700">Initial:</strong> ${submission.initialDiagnosis.pestDisease}</p>
+                        <p class="text-xs text-gray-500 mb-1">By ${submission.initialDiagnosis.diagnosedByName || 'N/A'}</p>
+                        ${submission.initialDiagnosis.notes ? `<p class="text-sm italic text-gray-700 bg-gray-50 p-2 rounded">"${submission.initialDiagnosis.notes}"</p>` : ''}
+                    </div>
+                `;
+            }
+            if (submission.finalDiagnosis) {
+                diagnosisHTML += `
+                    <div class="mt-3 pt-3 border-t border-gray-100">
+                        <p class="text-sm"><strong class="font-semibold text-gray-700">Final:</strong> ${submission.finalDiagnosis.pestDisease}</p>
+                        <p class="text-xs text-gray-500 mb-1">By ${submission.finalDiagnosis.diagnosedByName || 'N/A'}</p>
+                        ${submission.finalDiagnosis.notes ? `<p class="text-sm italic text-gray-700 bg-gray-50 p-2 rounded">"${submission.finalDiagnosis.notes}"</p>` : ''}
+                    </div>
+                `;
+            }
+
+            const contentHTML = `
+                <div class="space-y-4 text-sm">
+                    <div>
+                        <p class="font-bold text-base text-gray-800">${farm.farmName}</p>
+                        <p class="text-gray-600">Owned by: ${user.fullName}</p>
+                        <p class="text-xs text-gray-500">${user.barangay}, ${user.municipality}</p>
+                    </div>
+
+                    <div class="border-t pt-3">
+                        <h5 class="font-semibold text-gray-800 mb-1">Report Details</h5>
+                        <p><strong>Date:</strong> ${reportDate}</p>
+                        <p><strong>Symptoms:</strong> <span class="capitalize">${submission.symptoms.join(', ')}</span></p>
+                        <p><strong>Distribution:</strong> <span class="capitalize">${submission.distribution}</span></p>
+                        <p><strong>Severity:</strong> <span class="capitalize">${submission.severity}</span></p>
+                    </div>
+
+                    <div class="border-t pt-3">
+                        <h5 class="font-semibold text-gray-800 mb-1">Submitted Images</h5>
+                        ${imagesHTML}
+                    </div>
+
+                    ${diagnosisHTML ? `
+                    <div class="border-t pt-3">
+                        <h5 class="font-semibold text-gray-800 mb-1">Diagnosis</h5>
+                        ${diagnosisHTML}
+                    </div>` : ''}
+                </div>
+            `;
+
+            expertPanelContent.innerHTML = contentHTML;
+            expertPanel.classList.remove('hidden');
+        }
+
+        function closeExpertPanel() {
+            expertPanel.classList.add('hidden');
+        }
+
+        closeExpertPanelBtn.addEventListener('click', closeExpertPanel);
+
+
         let expertMap = null;
         async function loadExpertMap() {
             const mapContainer = document.getElementById('expert-map');
@@ -3474,10 +3571,9 @@
                                 color: pestDiseaseColors[pestDisease],
                                 weight: 2,
                                 fillOpacity: 0.5
-                            }).bindPopup(`<b>${pestDisease}</b><br>Farm: ${farmData.farmName}`);
-                            layers.push(polygon);
+                            });
 
-                            const center = L.polygon(farmData.polygonCoordinates.map(c => [c.lat, c.lng])).getBounds().getCenter();
+                            const center = L.polygon(latLngs).getBounds().getCenter();
                             const marker = L.marker(center, {
                                 icon: L.divIcon({
                                     className: 'custom-div-icon',
@@ -3485,7 +3581,19 @@
                                     iconSize: [30, 42],
                                     iconAnchor: [15, 42]
                                 })
-                            }).bindPopup(`<b>${pestDisease}</b><br>Farm: ${farmData.farmName}`);
+                            });
+
+                            const caseDetails = {
+                                farm: farmData,
+                                submission: submissionData,
+                                user: userDoc.data(),
+                                pestDisease: pestDisease
+                            };
+
+                            polygon.on('click', () => openExpertPanel(caseDetails));
+                            marker.on('click', () => openExpertPanel(caseDetails));
+
+                            layers.push(polygon);
                             layers.push(marker);
                         });
                     }


### PR DESCRIPTION
Adds a side panel to the expert dashboard that appears when a user clicks on a reported area (shapefile) on the map.

- Replaces the previous Leaflet popup with a detailed side panel.
- The panel displays comprehensive case information, including farm and farmer details, report specifics, submitted images, and diagnosis status.
- The dashboard layout is updated to be responsive, showing the panel alongside the map on larger screens.
- Includes the necessary JavaScript logic to show, hide, and dynamically populate the panel.