### PR TITLE
feat: Display management plan in expert case view

### DIFF
--- a/index.html
+++ b/index.html
@@ -3480,6 +3480,52 @@
                 `;
             }
 
+            // --- New logic for Management Plan ---
+            let managementPlanHTML = '';
+            const createManagementSection = (title, items) => {
+                if (!items || items.length === 0) return '';
+                return `
+                    <div class="mt-2">
+                        <h6 class="font-semibold text-gray-600">${title}</h6>
+                        <ul class="list-disc list-inside text-sm text-gray-600 mt-1 space-y-1">
+                            ${items.map(item => `<li>${item}</li>`).join('')}
+                        </ul>
+                    </div>
+                `;
+            };
+
+            if (submission.treatment) {
+                // Case 1: A treatment plan has been applied
+                managementPlanHTML = `
+                    <div class="border-t pt-3">
+                        <h5 class="font-semibold text-gray-800 mb-1">Applied Treatment Plan</h5>
+                        <p class="text-xs text-gray-500 mb-2">Prescribed by ${submission.treatment.createdByName || 'N/A'} on ${submission.treatment.createdAt?.toDate ? submission.treatment.createdAt.toDate().toLocaleDateString() : 'N/A'}</p>
+                        ${createManagementSection('Prevention', submission.treatment.prevention)}
+                        ${createManagementSection('Monitoring', submission.treatment.monitoring)}
+                        ${createManagementSection('Direct Control', submission.treatment.control)}
+                        <h6 class="font-semibold text-gray-600 mt-2">Instructions</h6>
+                        <p class="text-sm italic text-gray-700 bg-gray-50 p-2 rounded">${submission.treatment.instructions || 'No specific instructions provided.'}</p>
+                    </div>
+                `;
+            } else if (submission.finalDiagnosis && submission.finalDiagnosis.pestDisease) {
+                // Case 2: No treatment applied, but final diagnosis exists. Show recommendations.
+                const allItems = [...(pestAndDiseaseData.fungal_and_bacterial_diseases || []), ...(pestAndDiseaseData.major_insect_pests || [])];
+                const itemDetails = allItems.find(item => (item['Disease Name'] || item['Pest Common Name']) === submission.finalDiagnosis.pestDisease);
+
+                if (itemDetails && itemDetails.management) {
+                    managementPlanHTML = `
+                        <div class="border-t pt-3">
+                            <h5 class="font-semibold text-gray-800 mb-1">Recommended Management Plan</h5>
+                             <p class="text-xs text-gray-500 mb-2">Based on final diagnosis. No treatment has been applied yet.</p>
+                            ${createManagementSection('Prevention', itemDetails.management.prevention)}
+                            ${createManagementSection('Monitoring', itemDetails.management.monitoring)}
+                            ${createManagementSection('Direct Control', itemDetails.management.direct_control)}
+                        </div>
+                    `;
+                }
+            }
+
+
             const contentHTML = `
                 <div class="space-y-4 text-sm">
                     <div>
@@ -3506,6 +3552,8 @@
                         <h5 class="font-semibold text-gray-800 mb-1">Diagnosis</h5>
                         ${diagnosisHTML}
                     </div>` : ''}
+
+                    ${managementPlanHTML}
                 </div>
             `;
 


### PR DESCRIPTION
Adds a 'Management Plan' section to the expert dashboard's case details panel.

- If a treatment has been applied to a case, the panel displays the specific prevention, monitoring, and control actions that were prescribed.
- If no treatment has been applied but a final diagnosis exists, the panel displays the recommended management plan for the diagnosed pest or disease from the knowledge base.

This provides experts with immediate access to relevant management information when reviewing a case.