### PR TITLE
Fix "Submission data not found" error for extension workers

### DIFF
--- a/index.html
+++ b/index.html
@@ -2439,7 +2439,11 @@
                 isEditSubmissionMode = true;
 
                 try {
-                    const submissionDocRef = doc(db, 'users', currentUser.uid, 'farmLots', currentFarmId, 'submissions', currentSubmissionId);
+                    // FIX: Use the userId from the navigation context to fetch the correct farmer's data
+                    const currentState = navigationHistory[navigationHistory.length - 1];
+                    const targetUserId = currentState?.context?.userId || currentUser.uid;
+
+                    const submissionDocRef = doc(db, 'users', targetUserId, 'farmLots', currentFarmId, 'submissions', currentSubmissionId);
                     const submissionDocSnap = await getDoc(submissionDocRef);
 
                     if (submissionDocSnap.exists()) {


### PR DESCRIPTION
When an extension worker tried to edit a farmer's report, the application would incorrectly use the extension worker's user ID to look up the submission data in Firestore. This resulted in a "Submission data not found" error because the data is stored under the farmer's user ID.

This patch fixes the issue by retrieving the correct user ID from the navigation context, which stores the ID of the farmer whose data is being viewed. This ensures the application constructs the correct Firestore document path when fetching the submission for editing. A fallback to the current user's ID is kept for cases where a user is editing their own data.