### PR TITLE
feat: Use pestImages.json for login screen card images

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,6 +968,7 @@
 
         // --- 2. PWA & OFFLINE SETUP ---
         let pestAndDiseaseData = {}; // Global variable to hold the data
+        let pestImageData = {}; // Global variable to hold image data
 
         window.pestDiseaseDataPromise = (async function() {
             try {
@@ -981,6 +982,22 @@
             } catch (error) {
                 console.error('Failed to load pest and disease data:', error);
                 pestAndDiseaseData = null;
+                return false;
+            }
+        })();
+
+        window.pestImageDataPromise = (async function() {
+            try {
+                const response = await fetch('pestImages.json');
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                pestImageData = await response.json();
+                console.log('Pest image data loaded successfully.');
+                return true;
+            } catch (error) {
+                console.error('Failed to load pest image data:', error);
+                pestImageData = null;
                 return false;
             }
         })();
@@ -1095,11 +1112,19 @@
             if (!container) return;
             container.innerHTML = '';
 
-            await window.pestDiseaseDataPromise;
+            await Promise.all([window.pestDiseaseDataPromise, window.pestImageDataPromise]);
 
             if (!pestAndDiseaseData || (!pestAndDiseaseData.major_insect_pests && !pestAndDiseaseData.fungal_and_bacterial_diseases)) {
                 container.innerHTML = '<p class="text-white">Could not load pest and disease data.</p>';
                 return;
+            }
+
+            const imageMap = new Map();
+            if (pestImageData && pestImageData.pests) {
+                pestImageData.pests.forEach(p => imageMap.set(p.name, p.image_url));
+            }
+            if (pestImageData && pestImageData.diseases) {
+                pestImageData.diseases.forEach(d => imageMap.set(d.name, d.image_url));
             }
 
             const allItems = [
@@ -1112,8 +1137,7 @@
                 card.className = 'pest-card bg-white rounded-lg shadow-lg overflow-hidden m-2';
 
                 const name = item['Pest Common Name'] || item['Disease Name'];
-                // Placeholder image - in a real app, you'd have images for each
-                const imageUrl = 'https://placehold.co/200x150/cccccc/333333?text=' + name.split(' ').join('+');
+                const imageUrl = imageMap.get(name) || 'https://placehold.co/200x150/cccccc/333333?text=' + name.split(' ').join('+');
 
                 card.innerHTML = `
                     <img src="${imageUrl}" alt="${name}" class="w-full h-3/5 object-cover">
@@ -1967,7 +1991,7 @@
                 updateOnlineStatus();
 
                 // Wait for the address and pest/disease data to be ready
-                await Promise.all([window.addressDataPromise, window.pestDiseaseDataPromise]);
+                await Promise.all([window.addressDataPromise, window.pestDiseaseDataPromise, window.pestImageDataPromise]);
 
                 // Now that address data is loaded, populate the dropdowns
                 initializeAddressFilters();

--- a/pestImages.json
+++ b/pestImages.json
@@ -5,7 +5,7 @@
       "image_url": "https://bugwoodcloud.org/images/384x256/5535855.jpg"
     },
     {
-      "name": "Cutworm",
+      "name": "Cutworms",
       "image_url": "https://bugwoodcloud.org/images/384x256/1440105.jpg"
     },
     {
@@ -17,7 +17,7 @@
       "image_url": "https://bugwoodcloud.org/images/384x256/1147020.jpg"
     },
     {
-      "name": "Budworm",
+      "name": "Budworm / Bollworm / Caterpillar Complex",
       "image_url": "https://bugwoodcloud.org/images/384x256/1440111.jpg"
     },
     {
@@ -25,13 +25,13 @@
       "image_url": "https://bugwoodcloud.org/images/384x256/1402130.jpg"
     },
     {
-      "name": "Stem borer",
+      "name": "Stem Borer",
       "image_url": "https://bugwoodcloud.org/images/384x256/1599625.jpg"
     }
   ],
   "diseases": [
     {
-      "name": "Root knot",
+      "name": "Root-Knot Nematodes",
       "image_url": "https://bugwoodcloud.org/images/384x256/5442741.jpg"
     },
     {
@@ -39,7 +39,7 @@
       "image_url": "https://bugwoodcloud.org/images/384x256/1440050.jpg"
     },
     {
-      "name": "Blue Mold",
+      "name": "Blue Mold (Downy Mildew)",
       "image_url": "https://bugwoodcloud.org/images/384x256/1402003.jpg"
     },
     {
@@ -47,31 +47,31 @@
       "image_url": "https://bugwoodcloud.org/images/384x256/1524158.jpg"
     },
     {
-      "name": "Frog Eye Leaf Spot",
+      "name": "Frogeye Leaf Spot",
       "image_url": "https://bugwoodcloud.org/images/384x256/5368552.jpg"
     },
     {
-      "name": "Granville",
+      "name": "Granville Wilt (Bacterial Wilt)",
       "image_url": "https://bugwoodcloud.org/images/384x256/1402044.jpg"
     },
     {
-      "name": "Damping Off",
+      "name": "Damping-Off / Soft Rot / Hollow Stalk",
       "image_url": "https://bugwoodcloud.org/images/384x256/5556309.jpg"
     },
     {
-      "name": "Cucumber Mosaic",
+      "name": "Cucumber Mosaic Virus (CMV)",
       "image_url": "https://bugwoodcloud.org/images/384x256/1402026.jpg"
     },
     {
-      "name": "Potato Virus Y",
+      "name": "Potato Virus Y (PVY)",
       "image_url": "https://bugwoodcloud.org/images/384x256/1402028.jpg"
     },
     {
-      "name": "Target Spot",
+      "name": "Target Spot (Sore Shin)",
       "image_url": "https://bugwoodcloud.org/images/384x256/1440025.jpg"
     },
     {
-      "name": "WildFire",
+      "name": "Wildfire and Angular Leaf Spot",
       "image_url": "https://bugwoodcloud.org/images/384x256/1402023.jpg"
     }
   ]


### PR DESCRIPTION
This commit updates the login screen to use images from `pestImages.json` for the pest and disease cards.

The `index.html` file is modified to:
- Fetch image URLs from `pestImages.json`.
- Create a mapping from pest/disease names to image URLs.
- Use the correct image URL for each card, with a fallback to a placeholder image.