### PR TITLE
feat: Remove pest card names and display full-card images

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,10 +1147,7 @@
                 const imageUrl = imageMap.get(name) || 'https://placehold.co/200x150/cccccc/333333?text=' + name.split(' ').join('+');
 
                 card.innerHTML = `
-                    <img src="${imageUrl}" alt="${name}" class="w-full h-3/5 object-cover">
-                    <div class="p-3">
-                        <h4 class="font-bold text-lg text-black">${name}</h4>
-                    </div>
+                    <img src="${imageUrl}" alt="${name}" class="w-full h-full object-cover">
                 `;
 
                 card.addEventListener('click', () => {


### PR DESCRIPTION
Removes the text displaying the pest's name from the bottom of each pest card on the login screen. The image on the card is also updated to take up the full height of the card.

This change addresses the user's request to make the pest cards "whole pictures" without text.