### PR TITLE
feat: Add more soil variables to weather settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1393,7 +1393,14 @@
                     'wind_direction_10m': 'Wind Direction (10m)',
                     'wind_gusts_10m': 'Wind Gusts (10m)',
                     'soil_temperature_0cm': 'Soil Temperature (0cm)',
+                    'soil_temperature_6cm': 'Soil Temperature (6cm)',
+                    'soil_temperature_18cm': 'Soil Temperature (18cm)',
+                    'soil_temperature_54cm': 'Soil Temperature (54cm)',
                     'soil_moisture_0_to_1cm': 'Soil Moisture (0-1cm)',
+                    'soil_moisture_1_to_3cm': 'Soil Moisture (1-3cm)',
+                    'soil_moisture_3_to_9cm': 'Soil Moisture (3-9cm)',
+                    'soil_moisture_9_to_27cm': 'Soil Moisture (9-27cm)',
+                    'soil_moisture_27_to_81cm': 'Soil Moisture (27-81cm)',
                     'temperature_2m_max': 'Max Temperature (2m)',
                     'temperature_2m_min': 'Min Temperature (2m)',
                     'apparent_temperature_max': 'Max Apparent Temperature',
@@ -1418,8 +1425,9 @@
                 'weather_code', 'pressure_msl', 'surface_pressure', 'cloud_cover', 'cloud_cover_low',
                 'cloud_cover_mid', 'cloud_cover_high', 'visibility', 'evapotranspiration',
                 'et0_fao_evapotranspiration', 'vapour_pressure_deficit', 'wind_speed_10m', 'wind_direction_10m',
-                'wind_gusts_10m', 'soil_temperature_0cm', 'soil_moisture_0_to_1cm', 'is_day', 'sunshine_duration',
-                'uv_index'
+                'wind_gusts_10m', 'soil_temperature_0cm', 'soil_temperature_6cm', 'soil_temperature_18cm', 'soil_temperature_54cm',
+                'soil_moisture_0_to_1cm', 'soil_moisture_1_to_3cm', 'soil_moisture_3_to_9cm', 'soil_moisture_9_to_27cm', 'soil_moisture_27_to_81cm',
+                'is_day', 'sunshine_duration', 'uv_index'
             ];
             const dailyVariableNames = [
                 'weather_code', 'temperature_2m_max', 'temperature_2m_min', 'apparent_temperature_max',


### PR DESCRIPTION
This commit enhances the advanced weather settings by adding more soil-related variables as requested.

- The 'Hourly Weather Variables' dropdown now includes options for soil moisture and soil temperature at various depths (e.g., 0-1cm, 1-3cm, 6cm, 18cm, etc.).
- The display names for these new variables are formatted to be user-friendly.