### PR TITLE
Fix: Correct data format for address dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -3028,7 +3028,7 @@
             profileMunicipality = createMultiSelect('municipality-multiselect-container', 'Select Municipality', false);
             profileBarangay = createMultiSelect('barangay-multiselect-container', 'Select Barangay', false);
 
-            profileProvince.populate(window.philippineAddresses.provinces.map(p => p.name));
+            profileProvince.populate(window.philippineAddresses.provinces.map(p => ({ value: p.name, label: p.name })));
             profileMunicipality.disable();
             profileBarangay.disable();
 
@@ -3037,7 +3037,7 @@
                 profileBarangay.clear();
                 if (selectedProvinces.length > 0) {
                     const provinceData = window.philippineAddresses.provinces.find(p => p.name === selectedProvinces[0]);
-                    profileMunicipality.populate(provinceData.municipalities.map(m => m.name));
+                    profileMunicipality.populate(provinceData.municipalities.map(m => ({ value: m.name, label: m.name })));
                     profileMunicipality.enable();
                 } else {
                     profileMunicipality.disable();
@@ -3051,8 +3051,10 @@
                     const selectedProvinceName = profileProvince.getSelectedValues()[0];
                     const provinceData = window.philippineAddresses.provinces.find(p => p.name === selectedProvinceName);
                     const municipalityData = provinceData.municipalities.find(m => m.name === selectedMunicipalities[0]);
-                    profileBarangay.populate(municipalityData.barangays);
-                    profileBarangay.enable();
+                    if (municipalityData && municipalityData.barangays) {
+                        profileBarangay.populate(municipalityData.barangays.map(b => ({ value: b, label: b })));
+                        profileBarangay.enable();
+                    }
                 } else {
                     profileBarangay.disable();
                 }


### PR DESCRIPTION
The `createMultiSelect` component's `populate` method expects an array of objects with `value` and `label` properties. The previous code was incorrectly passing an array of strings.

This commit updates the `initializeAddressFilters` function to map the province, municipality, and barangay arrays to the correct `{value, label}` object format before passing them to the `populate` method.

Additionally, a check is added to ensure that a municipality has a `barangays` list before attempting to populate the barangay dropdown, preventing potential errors.