### PR TITLE
Fix: Expert dashboard map not displaying or querying data

### DIFF
--- a/index.html
+++ b/index.html
@@ -2529,6 +2529,7 @@
                     break;
                 case 'expertDashboard':
                 if (!window.expertFiltersInitialized) {
+                    await window.pestDiseaseDataPromise; // Wait for data to be loaded
                     initializeExpertDashboardFilters();
                     window.expertFiltersInitialized = true;
                 }
@@ -5651,14 +5652,16 @@
             const selectedBarangays = expertFilterBarangay ? expertFilterBarangay.getSelectedValues() : [];
 
             try {
-                const submissionsQuery = query(collectionGroup(db, 'submissions'), where("initialDiagnosis", "!=", null));
+                const submissionsQuery = query(collectionGroup(db, 'submissions'));
                 const submissionsSnapshot = await getDocs(submissionsQuery);
 
                 const layers = [];
                 const farmCache = {};
                 const userCache = {};
 
-                for (const submissionDoc of submissionsSnapshot.docs) {
+                const submissionsWithDiagnosis = submissionsSnapshot.docs.filter(doc => doc.data().initialDiagnosis);
+
+                for (const submissionDoc of submissionsWithDiagnosis) {
                     const submissionData = submissionDoc.data();
                     const farmLotRef = submissionDoc.ref.parent.parent;
                     const userRef = farmLotRef.parent.parent;


### PR DESCRIPTION
This commit fixes two issues preventing the expert dashboard map from functioning correctly:

1.  The Firestore query for submissions was failing, likely due to a missing composite index. The query has been modified to fetch all submissions, and the filtering for submissions with an initial diagnosis is now performed on the client side.

2.  A race condition was present where the expert dashboard filters could be initialized before the required pest and disease data was loaded. The code now awaits the data promise to resolve before initializing the filters, ensuring the dropdown is always populated correctly.