### PR TITLE
fix(sw): Remove self.skipWaiting() to prevent console error

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -66,7 +66,6 @@ self.addEventListener('install', event => {
             return Promise.all([coreAssetsPromise, ...remoteAssetsPromises]);
         })
     );
-    self.skipWaiting();
 });
 
 // 2. Activation: Clean up old caches.


### PR DESCRIPTION
Removes the `self.skipWaiting()` call from the service worker's `install` event.

This prevents the service worker from activating immediately upon installation, which can cause "Extension context invalidated" errors in the console when using development tools with live-reloading.