### PR TITLE
doc: Add PWA installation instructions for Android

### DIFF
--- a/PWA_INSTALL_INSTRUCTIONS.md
+++ b/PWA_INSTALL_INSTRUCTIONS.md
@@ -1,0 +1,32 @@
+# How to Install Agri-Guard on Your Android Phone
+
+The Agri-Guard application is a Progressive Web App (PWA), which means you can install it directly onto your phone from the browser. It will look and feel just like a native app, with its own icon on your home screen, and it will work even when you are offline.
+
+Follow these steps to install the app on your Android device using Google Chrome.
+
+---
+
+### Step-by-Step Instructions
+
+1.  **Open Google Chrome:**
+    *   Find and tap the Google Chrome icon on your phone.
+
+2.  **Go to the Agri-Guard Website:**
+    *   In the address bar at the top of Chrome, type the URL for the Agri-Guard application and press Enter.
+    *   *(Note: You will need to replace `your-website-url.com` with the actual address where the app is hosted.)*
+
+3.  **Open the Chrome Menu:**
+    *   Tap on the three-dot menu icon, which is usually in the top-right corner of the screen.
+
+4.  **Select "Install app":**
+    *   A menu will drop down. Look for the option that says **"Install app"** or **"Add to Home screen"** and tap on it. Chrome will automatically detect that the site is an installable PWA.
+
+5.  **Confirm the Installation:**
+    *   A pop-up will appear with the Agri-Guard app icon and name. Tap the **"Install"** button to confirm.
+
+6.  **Find the App on Your Home Screen:**
+    *   The app is now installed! You can find the Agri-Guard icon on your phone's home screen or in your app drawer, just like any other application you've downloaded from the Play Store.
+
+---
+
+You can now launch Agri-Guard directly from its icon. The app will open in its own full-screen window, and you can use it to create new reports and add farm lots even if you don't have an internet connection.


### PR DESCRIPTION
This project is a Progressive Web App (PWA), not a native Android application. The core features for adding farm lots and reports already exist and are designed to be mobile-friendly and work offline.

To clarify how to make the app accessible on a mobile device, this change adds a new file, `PWA_INSTALL_INSTRUCTIONS.md`.

This file provides clear, step-by-step instructions for users on how to 'install' the PWA to their Android home screen from Google Chrome, allowing it to function like a native app.