### PR TITLE
Fix notification toast blocking top buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2812,7 +2812,7 @@
             toastMessage.textContent = message;
 
             // Reset classes
-            toast.className = 'fixed top-5 right-5 text-white py-2 px-4 rounded-lg shadow-md transition-opacity duration-300';
+            toast.className = 'fixed bottom-5 right-5 text-white py-2 px-4 rounded-lg shadow-md transition-opacity duration-300';
 
             if (type === 'success') {
                 toast.classList.add('bg-green-600');


### PR DESCRIPTION
The `showToast` JavaScript function was incorrectly setting the class of the toast notification to `top-5`, causing it to appear at the top of the screen and block UI elements.

This change corrects the class to `bottom-5`, ensuring the toast appears at the bottom of the screen as intended by the initial HTML structure, thus resolving the UI obstruction.