### PR TITLE
Feature/extension worker role

### DIFF
--- a/index.html
+++ b/index.html
@@ -4157,7 +4157,10 @@
                 document.getElementById('save-farm-map-btn').textContent = 'Save Farm Area';
             }
 
-            showScreen('farmSetup');
+            const lastContext = navigationHistory[navigationHistory.length - 1]?.context || {};
+            const newContext = { ...lastContext, label: 'Map Farm Plot' };
+            showScreen('farmSetup', newContext);
+
             // Invalidate map size and re-center, needed when map is in a hidden div
             setTimeout(() => {
                 initializeMap(); // General map init


### PR DESCRIPTION
fix: Correctly associate farms created by Extension Workers

This commit fixes a critical bug where farm lots created by an Extension Worker for a farmer were incorrectly being saved under the Extension Worker's own account.

The issue was caused by the navigation context, which contains the target farmer's ID, being lost during the transition to the farm mapping screen (`farm-setup-screen`). The `showScreen` function was called without passing the existing context along.

The fix ensures that the navigation context is preserved and passed to the farm setup screen. This guarantees that when the farm is saved, it is correctly associated with the farmer being managed by the Extension Worker.